### PR TITLE
Making React Developer Tools Happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,16 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.1.21",
+    "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
-    "babel-loader": "^6.1.0",
-
-    "webpack": "^1.12.6",
     "copy-webpack-plugin": "^0.2.0",
-    "webpack-dev-server": "^1.12.1",
-    "react-hot-loader": "^1.3.0"
+    "react-hot-loader": "^1.3.0",
+    "webpack": "^1.12.6",
+    "webpack-dev-server": "^1.12.1"
   },
   "dependencies": {
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
     module: {
         loaders: [
             {
-                loader: 'react-hot',
+                loader: 'react-hot-loader',
                 test: dir_js,
             },
             {
@@ -30,6 +30,7 @@ module.exports = {
                 query: {
                     presets: ['es2015', 'react'],
                 },
+                exclude: /node_modules/
             }
         ]
     },
@@ -39,7 +40,15 @@ module.exports = {
             { from: dir_html } // to: output.path
         ]),
         // Avoid publishing files when compilation fails
-        new webpack.NoErrorsPlugin()
+        new webpack.NoErrorsPlugin(),
+
+        new webpack.DefinePlugin({
+          'process.env': {
+            NODE_ENV: JSON.stringify('production')
+          }
+        }),
+
+        new webpack.optimize.UglifyJsPlugin()
     ],
     stats: {
         // Nice colored output


### PR DESCRIPTION
hey guys!

I was running this benchmark locally and the react devtools was warning that the benchmark was using the development version of React:

![screen shot 2017-07-31 at 4 09 30 pm](https://user-images.githubusercontent.com/829902/28762534-89162fa8-760b-11e7-88e2-1488d311fbe0.png)


So, I've updated the webpack config (this PR) [based on React Docs](https://facebook.github.io/react/docs/optimizing-performance.html#webpack):

![screen shot 2017-07-31 at 4 10 15 pm](https://user-images.githubusercontent.com/829902/28762551-9b710af6-760b-11e7-8a96-fc52d25ecbe1.png)


And, to make the devtools happy, I also updated the React version:

![screen shot 2017-07-31 at 4 11 00 pm](https://user-images.githubusercontent.com/829902/28762641-36e305f2-760c-11e7-9553-31110c1b7e9d.png)


Quite interesting, right? Let's see what React 16 brings to the table! :)